### PR TITLE
Support sequelize v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var customulize = require('customulize'),
 
 module.exports = function(models){
     var firstModel = models[Object.keys(models)[0]];
+    if (typeof firstModel === 'function') {
+        firstModel = new firstModel();
+    }
     if(firstModel && firstModel.sequelize && !firstModel.sequelize.cps){
         firstModel.sequelize.cps = {
             query: abbott(firstModel.sequelize.query.bind(firstModel.sequelize))

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "homepage": "https://github.com/gbenvenuti/sequelize-cps",
   "dependencies": {
     "abbott": "^1.1.2",
-    "customulize": "^1.0.2"
+    "customulize": "^1.0.6"
   },
   "devDependencies": {
     "grape": "^1.0.3",
-    "mockery": "^1.4.0"
+    "mockery": "^1.4.0",
+    "tape": "^4.8.0"
   }
 }


### PR DESCRIPTION
To be able to patch `instance.sequelize` with cps methods, sequelize v4 needs to have an instanciated model object.